### PR TITLE
feat(heroSheetUpdate): add prefix for object

### DIFF
--- a/src/app/hero-sheet/constants/hero-base-path.const.ts
+++ b/src/app/hero-sheet/constants/hero-base-path.const.ts
@@ -1,0 +1,1 @@
+export const HeroBasePath = 'heroBasicInfo';

--- a/src/app/hero-sheet/dtos/hero-sheet-changes.dto.ts
+++ b/src/app/hero-sheet/dtos/hero-sheet-changes.dto.ts
@@ -8,10 +8,11 @@ export class HeroSheetChangesDto {
   heroSheetId: string;
 
   @ApiProperty({
+    example: ['characteristics', '1'],
     examples: [
-      ['heroBasicInfo', 'characterName'],
-      ['heroBasicInfo', 'characteristics[0]', 'characteristicName'],
-      ['heroBasicInfo', 'characteristics', '0', 'characteristicName'],
+      ['characterName'],
+      ['characteristics[0]', 'characteristicName'],
+      ['characteristics', '0', 'characteristicName'],
     ],
     description: 'Array of strings with the path of property to update',
   })
@@ -19,6 +20,10 @@ export class HeroSheetChangesDto {
   propertyToUpdate: string[];
 
   @ApiProperty({
+    example: {
+      characteristicName: 'Gambler',
+      characteristicBonus: '+2',
+    },
     description: 'The value of the property to update',
   })
   value: string | number | Object;

--- a/src/app/hero-sheet/hero-sheet.service.spec.ts
+++ b/src/app/hero-sheet/hero-sheet.service.spec.ts
@@ -2,7 +2,6 @@ import { HeroSheetData } from 'app/hero-sheet/data/hero-sheet.data';
 import { HeroSheetChangesDto } from 'app/hero-sheet/dtos/hero-sheet-changes.dto';
 import { UpdateHeroSheetErrors } from 'app/hero-sheet/enums/update-hero-sheet-errors.enum';
 import { HeroSheetService } from 'app/hero-sheet/hero-sheet.service';
-import { NonUpdatableProperties } from 'app/hero-sheet/maps/non-updatable-properties.map';
 import { HeroSheet } from 'app/hero-sheet/schemas/hero-sheet.schema';
 import { Model } from 'mongoose';
 
@@ -32,15 +31,9 @@ describe('Hero Sheet Service', () => {
     const testThatShouldFail: HeroSheetUpdateShouldFailCase[] = [
       {
         a: {
-          propertyToUpdate: [NonUpdatableProperties[0]],
+          propertyToUpdate: [],
         },
-        b: UpdateHeroSheetErrors.BasePropertyError,
-      },
-      {
-        a: {
-          propertyToUpdate: [NonUpdatableProperties[1]],
-        },
-        b: UpdateHeroSheetErrors.BasePropertyError,
+        b: UpdateHeroSheetErrors.InvalidPropertyPath,
       },
     ];
 

--- a/src/app/hero-sheet/hero-sheet.service.ts
+++ b/src/app/hero-sheet/hero-sheet.service.ts
@@ -5,10 +5,10 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
+import { HeroBasePath } from 'app/hero-sheet/constants/hero-base-path.const';
 import { HeroSheetChangesDto } from 'app/hero-sheet/dtos/hero-sheet-changes.dto';
 import { UpdateHeroSheetErrors } from 'app/hero-sheet/enums/update-hero-sheet-errors.enum';
 import { createSheetId } from 'app/hero-sheet/helper/create-hero-sheet-id.helper';
-import { NonUpdatableProperties } from 'app/hero-sheet/maps/non-updatable-properties.map';
 import { isNil, omit, set } from 'lodash';
 import { Model } from 'mongoose';
 import { CreateHeroSheetDto } from './dtos/create-hero-sheet.dto';
@@ -73,26 +73,25 @@ export class HeroSheetService {
     propertyToUpdate,
     value,
   }: HeroSheetChangesDto) {
-    const heroSheet = await this.getHeroSheetById(heroSheetId);
-    const heroSheetObject = heroSheet.toObject();
-    const baseProperty = propertyToUpdate[0];
-
-    if (
-      NonUpdatableProperties.includes(baseProperty) &&
-      propertyToUpdate.length === 1
-    ) {
-      throw new BadRequestException(UpdateHeroSheetErrors.BasePropertyError);
-    }
-    const objectPath = propertyToUpdate.join('.');
-
-    set(heroSheetObject, objectPath, value);
-
     try {
+      const heroSheet = await this.getHeroSheetById(heroSheetId);
+      const heroSheetObject = heroSheet.toObject();
+
+      if (propertyToUpdate.length === 0) {
+        throw new Error(UpdateHeroSheetErrors.InvalidPropertyPath);
+      }
+
+      const propertyWithBasePath = [HeroBasePath, ...propertyToUpdate];
+
+      const objectPath = propertyWithBasePath.join('.');
+
+      set(heroSheetObject, objectPath, value);
+
       await this.heroSheetModel
         .updateOne({ sheetId: heroSheet.sheetId }, heroSheetObject)
         .exec();
     } catch (error) {
-      throw new InternalServerErrorException(error);
+      throw new InternalServerErrorException(error.message);
     }
 
     return 'The hero sheet has been updated.';


### PR DESCRIPTION
- Se ha actualizado el endpoint de actualización de la hoja de personajes para que ahora no tengas que escribir el prefijo "heroBasicInfo", puesto que solo se van a actualizar los datos dentro de este mismo
- Se han corregido los ejemplos del endpoint en swagger